### PR TITLE
Allow https or http downloads

### DIFF
--- a/topcat_selenium_test.py
+++ b/topcat_selenium_test.py
@@ -1127,15 +1127,25 @@ def test_cart_clear():
 #---Download--------------------------------------------------------------------
 
 # Download Datafile via action button
-# TODO - Add varaible for which file gets selected (By name if possible)
 def test_download_action():
 
-    datafile_name = "Datafile 1"
+    # Datafile name that will be used if we can't extract it
+    datafile_name = "Datafile N"
 
-    print("Download By Action: ", end='')
+    print("Get first datafile name: ", end='')
     browser.get(datafile_url)
     time.sleep(base_sleep_time)
 
+    try:
+        # The following assumes that the datafile name we want is in the first span within the first ui-grid-cell div
+        # (and that the CSS selector below selects the Download button on the same row)
+        datafile_name = browser.find_element_by_xpath('//div[@class="ui-grid-cell-contents ng-scope"]/span').text
+        print(txt.Success + '(found "' + datafile_name + '")')
+    except NoSuchElementException as ex:
+        fail_test("")
+        print(ex)
+
+    print("Download By Action: ", end='')
     try:
         element_wait((By.CSS_SELECTOR, 'a[translate="DOWNLOAD_ENTITY_ACTION_BUTTON.TEXT"]'))
         element_click('a[translate="DOWNLOAD_ENTITY_ACTION_BUTTON.TEXT"]')

--- a/topcat_selenium_test.py
+++ b/topcat_selenium_test.py
@@ -1192,10 +1192,21 @@ def test_download_cart():
         print (txt.Failed)
 
 
+    # Check http method option availiable
+    httpMethodExists = False
+    print("Cart Transport/Access Method 'http' Option Exists: ", end='')
+    if (element_exists('option[label="http"]') == True):
+        print(txt.Success)
+        httpMethodExists = True
+    else:
+        fail_test(" (http method not an option)")
+
     # Check https method option availiable
+    httpsMethodExists = False
     print("Cart Transport/Access Method 'https' Option Exists: ", end='')
     if (element_exists('option[label="https"]') == True):
         print(txt.Success)
+        httpsMethodExists = True
     else:
         fail_test(" (https method not an option)")
 
@@ -1207,11 +1218,23 @@ def test_download_cart():
         fail_test(" (globus method not an option)")
 
 
-    # Download
-    print("Cart Download Via https: ", end='')
+    if httpsMethodExists:
+        # Download
+        print("Cart Download Via https: ", end='')
 
-    # Select https if not already selected
-    Select(element_find('select[ng-model="download.transportType"]')).select_by_visible_text('https')
+        # Select https if not already selected
+        Select(element_find('select[ng-model="download.transportType"]')).select_by_visible_text('https')
+    elif httpMethodExists:
+        # Download
+        print("Cart Download Via http: ", end='')
+
+        # Select https if not already selected
+        Select(element_find('select[ng-model="download.transportType"]')).select_by_visible_text('http')
+    else:
+        print('No download option for http or https - skipping cart download tests.')
+        return
+
+    # Otherwise, test downloading using the selected method
 
     # Click 'OK'
     element_wait((By.CSS_SELECTOR, 'button[translate="CART.DOWNLOAD.MODAL.BUTTON.OK.TEXT"]'))


### PR DESCRIPTION
The branch for this PR contains two changes:
  - test for both https and http downloads (original only did https)
  - get download datafile name from the page content (was hard-wired)
